### PR TITLE
Serial output

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ _updateServer.setup(&_server, "/customroute", "username", "password");
 >
 >This will enable the library to print logs to the Serial.
 
+>### Selecting another serial port
+>In case you use another serial port, such as Serial0,Serial1 or Serial2, if your controller support those, you can add '-DESPASYNCHTTPUPDATESERVER_SERIAL0' Build Flag to your environment, adjust the final digit to the serial port you want to use  
+
 ## TODO:
 - ESP8266 LittleFS support
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,8 @@ _updateServer.setup(&_server, "/customroute", "username", "password");
 > In order to debug the library funtionality, you can add the `-DESPASYNCHTTPUPDATESERVER_DEBUG` Build Flag to your environment.
 >
 >This will enable the library to print logs to the Serial.
-
 >### Selecting another serial port
->In case you use another serial port, such as Serial0,Serial1 or Serial2, if your controller support those, you can add '-DESPASYNCHTTPUPDATESERVER_SERIAL0' Build Flag to your environment, adjust the final digit to the serial port you want to use  
+>In case you use another serial port, such as Serial0,Serial1 or Serial2, if your controller support those, you can add `-DESPASYNCHTTPUPDATESERVER_SERIAL0` Build Flag to your environment, adjust the final digit to the serial port you want to use  
 
 ## TODO:
 - ESP8266 LittleFS support

--- a/src/ESPAsyncHTTPUpdateServer.cpp
+++ b/src/ESPAsyncHTTPUpdateServer.cpp
@@ -16,7 +16,16 @@
   #error "This library only supports boards with an ESP8266 or ESP32 processor."
 #endif
 
-#define SerialOutput Serial
+#ifdef ESPASYNCHTTPUPDATESERVER_SERIAL0
+    #define SerialOutput Serial0
+#elif defined(ESPASYNCHTTPUPDATESERVER_SERIAL1)
+    #define SerialOutput Serial1
+#elif defined(ESPASYNCHTTPUPDATESERVER_SERIAL2)
+    #define SerialOutput Serial2
+#else
+    #define SerialOutput Serial
+#endif
+
 
 static const char serverIndex[] PROGMEM =
     R"(<!DOCTYPE html>


### PR DESCRIPTION
Following your comment on my previous pull request, I use Build Flags, instead of modifying the .cpp file. User needs to add -DESPASYNCHTTPUPDATESERVER_SERIAL0 by example to their Build Flags and it will use Serial0 instead of Serial. 